### PR TITLE
[CI Test] Add support of CMake config modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,10 @@ set (DIR_SHARE_LOCALE ${DIR_SHARE}/locale/)
 
 ######## Configuration
 
+include(CMakePackageConfigHelpers)
+
+set(targets_export_name OpenCCTargets)
+
 configure_file(
   opencc.pc.in
   opencc.pc
@@ -116,6 +120,26 @@ install(
     ${CMAKE_CURRENT_BINARY_DIR}/opencc.pc
   DESTINATION
     ${DIR_LIBRARY}/pkgconfig
+)
+
+write_basic_package_version_file(
+  OpenCCConfigVersion.cmake
+  VERSION ${OPENCC_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
+configure_package_config_file(
+  OpenCCConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/OpenCCConfig.cmake
+  INSTALL_DESTINATION lib/cmake/opencc
+)
+
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/OpenCCConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/OpenCCConfigVersion.cmake
+  DESTINATION
+    lib/cmake/opencc
 )
 
 ######## Compiler flags

--- a/OpenCCConfig.cmake.in
+++ b/OpenCCConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake)
+check_required_components(OpenCC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,6 +112,7 @@ configure_file(
   "${PROJECT_BINARY_DIR}/src/opencc_config.h")
 
 add_library(libopencc ${LIBOPENCC_SOURCES} ${LIBOPENCC_HEADERS})
+add_library(OpenCC::OpenCC ALIAS libopencc)
 set_target_properties(libopencc PROPERTIES POSITION_INDEPENDENT_CODE ON)
 source_group(libopencc FILES ${LIBOPENCC_SOURCES} ${LIBOPENCC_HEADERS})
 target_link_libraries(libopencc marisa)
@@ -131,6 +132,8 @@ set_target_properties(
       CXX
     OUTPUT_NAME
       opencc
+    EXPORT_NAME
+      OpenCC
     VERSION
       ${OPENCC_VERSION_MAJOR}.${OPENCC_VERSION_MINOR}.${OPENCC_VERSION_REVISION}
     SOVERSION
@@ -139,11 +142,24 @@ set_target_properties(
 
 # Installation
 
+if (USE_SYSTEM_MARISA)
+  set(INSTALL_TARGETS libopencc)
+else()
+  set(INSTALL_TARGETS libopencc marisa)
+endif()
+
 install(
-  TARGETS libopencc
-  LIBRARY DESTINATION ${DIR_LIBRARY}
-  ARCHIVE DESTINATION ${DIR_LIBRARY}
+  TARGETS ${INSTALL_TARGETS} EXPORT ${targets_export_name}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
+)
+
+install(
+  EXPORT ${targets_export_name}
+  FILE ${targets_export_name}.cmake
+  DESTINATION lib/cmake/opencc
+  NAMESPACE OpenCC::
 )
 
 install(


### PR DESCRIPTION
Currently OpenCC only has a pkg-config file, it's good for systems to locate standalone OpenCC package. But if a project using CMake that want to make OpenCC as its subproject / dependency, it will need to write a FindOpenCC.cmake to find package, which is a hassle to do so. And for Android platform, pkg-config is unavailable since NDK doesn't support it. So it's necessary to add support of CMake modules, then a project is able to just `find_package(OpenCC)` and `target_link_libraries(<project_library_name> OpenCC::OpenCC)` to add OpenCC as subproject / dependency.